### PR TITLE
[backend] Fix Middleware Sequence

### DIFF
--- a/backend/server/server.go
+++ b/backend/server/server.go
@@ -45,8 +45,8 @@ func (s *Server) Shutdown() {
 // InitMiddleware initializes all middlewares
 func (s *Server) InitMiddleware() {
 	s.router.Use(s.loggingMiddleware)
-	s.router.Use(s.jwtMiddleware)
 	s.router.Use(s.corsMiddleware)
+	s.router.Use(s.jwtMiddleware)
 }
 
 // Serve runs the server


### PR DESCRIPTION
Previously if a request is unauthorized the CORS middleware would get skipped and the browser wouldn't get the proper CORS headers.