### PR TITLE
chore: sync frontend vue version bump 2025.07.01-db03b95-alpha

### DIFF
--- a/frontend/vue/package.json
+++ b/frontend/vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "balances-frontend-vue",
   "private": true,
-  "version": "2025.06.29-66b9e7f-alpha",
+  "version": "2025.07.01-db03b95-alpha",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Auto-syncing frontend vue version bump to master