### PR TITLE
chore: sync frontend vue version bump 2025.07.02-56fdef8-alpha

### DIFF
--- a/frontend/vue/package.json
+++ b/frontend/vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "balances-frontend-vue",
   "private": true,
-  "version": "2025.07.02-f775792-alpha",
+  "version": "2025.07.02-56fdef8-alpha",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Auto-syncing frontend vue version bump to master