### PR TITLE
chore: sync frontend vue version bump 2025.07.08-7edc05b-alpha

### DIFF
--- a/frontend/vue/package.json
+++ b/frontend/vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "balances-frontend-vue",
   "private": true,
-  "version": "2025.07.07-75f136f-alpha",
+  "version": "2025.07.08-7edc05b-alpha",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Auto-syncing frontend vue version bump to master